### PR TITLE
Add eslint-plugin-tailwindcss as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,24 +66,6 @@ export default damisparks(
 )
 ```
 
-#### Tailwind CSS Support
-
-To use the Tailwind CSS preset, you need to install the `eslint-plugin-tailwindcss` package:
-
-```bash
-pnpm add -D eslint-plugin-tailwindcss
-```
-
-This is an optional dependency to avoid compatibility issues with different versions. If you experience issues with eslint-plugin-tailwindcss v4, you can specify v3 in your package.json:
-
-```json
-{
-  "devDependencies": {
-    "eslint-plugin-tailwindcss": "^3.18.0"
-  }
-}
-```
-
 ### Nuxt Integration
 
 This package provides custom rules that can be used with [Nuxt](https://nuxt.com). The recommended approach to use this config is via the Nuxt module.

--- a/package.json
+++ b/package.json
@@ -23,22 +23,14 @@
     "lint:fix": "eslint . --fix",
     "dev": "config-inspector"
   },
-  "peerDependencies": {
-    "eslint-plugin-tailwindcss": "^3.18.0"
-  },
-  "peerDependenciesMeta": {
-    "eslint-plugin-tailwindcss": {
-      "optional": true
-    }
-  },
   "dependencies": {
-    "@antfu/eslint-config": "^4.12.0"
+    "@antfu/eslint-config": "^4.12.0",
+    "eslint-plugin-tailwindcss": "^3.18.0"
   },
   "devDependencies": {
     "@eslint/config-inspector": "^1.0.2",
     "eslint": "^9.25.0",
-    "eslint-plugin-format": "^0.1.3",
-    "eslint-plugin-tailwindcss": "^3.18.0"
+    "eslint-plugin-format": "^0.1.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@antfu/eslint-config':
         specifier: ^4.12.0
         version: 4.12.0(@typescript-eslint/utils@8.30.1(eslint@9.25.0(jiti@1.21.6))(typescript@5.6.2))(@vue/compiler-sfc@3.5.11)(eslint-plugin-format@0.1.3(eslint@9.25.0(jiti@1.21.6)))(eslint@9.25.0(jiti@1.21.6))(typescript@5.6.2)
+      eslint-plugin-tailwindcss:
+        specifier: ^3.18.0
+        version: 3.18.0(tailwindcss@3.4.13)
     devDependencies:
       '@eslint/config-inspector':
         specifier: ^1.0.2
@@ -21,9 +24,6 @@ importers:
       eslint-plugin-format:
         specifier: ^0.1.3
         version: 0.1.3(eslint@9.25.0(jiti@1.21.6))
-      eslint-plugin-tailwindcss:
-        specifier: ^3.18.0
-        version: 3.18.0(tailwindcss@3.4.13)
 
 packages:
 


### PR DESCRIPTION
Include eslint-plugin-tailwindcss in the project dependencies to enhance Tailwind CSS support in the linting process. Update the README to reflect this change.