### PR TITLE
Move onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ["22"]
+        node: ['22']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
     "@eslint/config-inspector": "^1.0.2",
     "eslint": "^9.26.0",
     "eslint-plugin-format": "^1.0.2"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver


### PR DESCRIPTION
Transfer the `onlyBuiltDependencies` configuration from `package.json` to `pnpm-workspace.yaml` for better organization and management of dependencies.